### PR TITLE
Refactor lol/ module to use api_session

### DIFF
--- a/lol/champSelect.py
+++ b/lol/champSelect.py
@@ -2,29 +2,14 @@ import json
 
 import requests
 
-from . import lockfile, summoner
-
-def shallow_call(func):
-  def wrapper():
-    result = func()
-
-    if(not result.ok):
-      return None
-  
-    return result.json()
-
-  return wrapper
-
-@shallow_call
-def get_session():
-  url = lockfile.get_url("lol-champ-select/v1/session")
-  
-  return lockfile.get_session().get(
-    url=url
-  )
+from .lockfile import api_session
+from . import summoner
 
 def get_current_action():
-  session = get_session()
+  response = api_session.get("lol-champ-select/v1/session")
+  if not response.ok:
+    return None
+  session = response.json()
 
   if(session is None):
     return
@@ -45,12 +30,9 @@ def get_current_action():
 def complete_actions(data):
   action_id = data["id"]
 
-  path_url = lockfile.get_url(f"lol-champ-select/v1/session/actions/{action_id}")
-  comlete_url = lockfile.get_url(f"lol-champ-select/v1/session/actions/{action_id}/complete")
-
   # Update action
-  lockfile.get_session().patch(
-    url=path_url,
+  api_session.patch(
+    url=f"lol-champ-select/v1/session/actions/{action_id}",
     headers={
       "Content-Type": "application/json"
     },
@@ -58,13 +40,16 @@ def complete_actions(data):
   )
 
   # Complete
-  lockfile.get_session().post(
-    url=comlete_url
+  api_session.post(
+    url=f"lol-champ-select/v1/session/actions/{action_id}/complete"
   )
 
 def get_local_player():
   summoner_data = summoner.get_summoner()
-  session = get_session()
+  response = api_session.get("lol-champ-select/v1/session")
+  if not response.ok:
+    return None
+  session = response.json()
 
   if(session is None):
     return None
@@ -78,16 +63,12 @@ def get_local_player():
   return None
 
 def reroll():
-  url = lockfile.get_url("lol-champ-select/v1/session/my-selection/reroll")
-
-  lockfile.get_session().post(
-    url=url
+  api_session.post(
+    url="lol-champ-select/v1/session/my-selection/reroll"
   )
 
 
 def swapFromBench(champId: int):
-  url = lockfile.get_url(f"lol-champ-select/v1/session/bench/swap/{champId}")
-
-  lockfile.get_session().post(
-    url=url
+  api_session.post(
+    url=f"lol-champ-select/v1/session/bench/swap/{champId}"
   )

--- a/lol/client.py
+++ b/lol/client.py
@@ -1,12 +1,10 @@
 import requests
 
-from . import lockfile
+from .lockfile import api_session
 
 def get_gameflow_phase() -> str:
-  url = lockfile.get_url("lol-gameflow/v1/gameflow-phase")
-
-  response = lockfile.get_session().get(
-    url=url
+  response = api_session.get(
+    url="lol-gameflow/v1/gameflow-phase"
   )
 
   if(not response.ok):

--- a/lol/eog.py
+++ b/lol/eog.py
@@ -1,12 +1,10 @@
 import requests
 
-from . import lockfile
+from .lockfile import api_session
 
 def get_eog_data():
-  url = lockfile.get_url("lol-end-of-game/v1/eog-stats-block")
-
-  response = lockfile.get_session().get(
-    url=url
+  response = api_session.get(
+    url="lol-end-of-game/v1/eog-stats-block"
   )
 
   if(not response.ok):

--- a/lol/inventory.py
+++ b/lol/inventory.py
@@ -3,12 +3,11 @@ from typing import List
 
 import requests
 
-from . import lockfile
+from .lockfile import api_session
 
 def get_all_loot(type: str = ""):
-  url = lockfile.get_url("lol-loot/v1/player-loot")
-  result = lockfile.get_session().get(
-    url=url
+  result = api_session.get(
+    url="lol-loot/v1/player-loot"
   )
 
   if(not result.ok):
@@ -28,9 +27,8 @@ def get_loot_by_lootId(id: str):
 
 def yolo_disenchant(itemIds: List[str], count: int = 1):
 
-  url = lockfile.get_url(f"lol-loot/v1/recipes/CHAMPION_RENTAL_disenchant/craft?repeat={count}")
-  result = lockfile.get_session().post(
-    url=url,
+  result = api_session.post(
+    url=f"lol-loot/v1/recipes/CHAMPION_RENTAL_disenchant/craft?repeat={count}",
     headers={
       "Content-Type": "application/json"
     },

--- a/lol/summoner.py
+++ b/lol/summoner.py
@@ -1,12 +1,10 @@
 import requests
 
-from . import lockfile
+from .lockfile import api_session
 
 def get_summoner():
-  url = lockfile.get_url("lol-summoner/v1/current-summoner")
-
-  result = lockfile.get_session().get(
-    url=url
+  result = api_session.get(
+    url="lol-summoner/v1/current-summoner"
   )
 
   if(not result.ok):


### PR DESCRIPTION
Updated the lol/ module to use the `api_session` object instead of manually formatting URLs and calling `lockfile.get_session()`. The `lobby.py` file was already updated and used as an example for `champSelect.py`, `client.py`, `eog.py`, `inventory.py`, and `summoner.py`. All API URLs are now relative.

---
*PR created automatically by Jules for task [5123097470958153782](https://jules.google.com/task/5123097470958153782) started by @tobman4*